### PR TITLE
Gracefully handle array dimension of mask_labels

### DIFF
--- a/example_segmentation_2/custom/segmentation_to_classification.py
+++ b/example_segmentation_2/custom/segmentation_to_classification.py
@@ -3,14 +3,12 @@ import numpy as np
 
 
 class SegmentationToClassification(BaseTransform):
-    """
-    Transforms a segmentation output into a classification output. by simply taking
+    """Transforms a segmentation output into a classification output. by simply taking
     the label with more pixels in the segmentation mask.
     """
 
     def __init__(self, highest_pixel_count: int = 1, **params):
-        """
-        Any parameters defined in yaml file will be passed to init. Store the value
+        """Any parameters defined in yaml file will be passed to init. Store the value
         passed in self so you can access them in the call method.
 
         Parameters
@@ -30,8 +28,7 @@ class SegmentationToClassification(BaseTransform):
         self.highest_score_position = highest_pixel_count
 
     def __call__(self, inputs: DataItem) -> DataItem:
-        """
-        Return a new DataItem with transformed attributes. DataItem has following
+        """Return a new DataItem with transformed attributes. DataItem has following
         attributes:
 
         image - input image.
@@ -64,11 +61,13 @@ class SegmentationToClassification(BaseTransform):
         score = float(
             counts_sorted[self.highest_score_position - 1] / np.sum(counts_sorted)
         )
-
+        mask_labels = inputs.mask_labels
+        if mask_labels is not None and len(mask_labels.shape) == 3:
+            mask_labels = mask_labels[:, :, 0]
         return DataItem(
             image=inputs.image,
             label=label,
             score=score,
             mask_scores=inputs.mask_scores,
-            mask_labels=inputs.mask_labels,
+            mask_labels=mask_labels,
         )

--- a/example_segmentation_2/custom/segmentation_to_classification.py
+++ b/example_segmentation_2/custom/segmentation_to_classification.py
@@ -3,12 +3,14 @@ import numpy as np
 
 
 class SegmentationToClassification(BaseTransform):
-    """Transforms a segmentation output into a classification output. by simply taking
+    """
+    Transforms a segmentation output into a classification output. by simply taking
     the label with more pixels in the segmentation mask.
     """
 
     def __init__(self, highest_pixel_count: int = 1, **params):
-        """Any parameters defined in yaml file will be passed to init. Store the value
+        """
+        Any parameters defined in yaml file will be passed to init. Store the value
         passed in self so you can access them in the call method.
 
         Parameters
@@ -28,7 +30,8 @@ class SegmentationToClassification(BaseTransform):
         self.highest_score_position = highest_pixel_count
 
     def __call__(self, inputs: DataItem) -> DataItem:
-        """Return a new DataItem with transformed attributes. DataItem has following
+        """
+        Return a new DataItem with transformed attributes. DataItem has following
         attributes:
 
         image - input image.


### PR DESCRIPTION
## Description
Add additional procedure to check the dimension of `mask_labels` and squeeze it if the dimension is 2. 

I think this is likely some issue when we generate the output mask_labels and set a soft requirement, so the output might have an additional, unexpected dimension. 

## Testing
I have tested on platform and it will solve the problem. 